### PR TITLE
Improve to default params using jq's alternative operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 ci/secret.yml
 .DS_Store
+payload.json

--- a/assets/out
+++ b/assets/out
@@ -36,12 +36,9 @@ cd $source_dir
 exe kubectl $kubectl_command
 
 # Optional. The number of seconds that waits until all pods are ready. Defaults to `30`.
-wait_until_ready="$(jq -r '.params.wait_until_ready // ""' < $payload)"
-[[ -z "$wait_until_ready" ]] && wait_until_ready=30
-
+wait_until_ready="$(jq -r '.params.wait_until_ready // 30' < $payload)"
 # Optional. The interval (sec) on which to check whether all pods are ready or not. Defaults to `3`.
-wait_until_ready_interval="$(jq -r '.params.wait_until_ready_interval // ""' < $payload)"
-[[ -z "$wait_until_ready_interval" ]] && wait_until_ready_interval=3
+wait_until_ready_interval="$(jq -r '.params.wait_until_ready_interval // 3' < $payload)"
 
 if [[ "$wait_until_ready" -ne 0 ]]; then
   wait_until_pods_ready $wait_until_ready $wait_until_ready_interval

--- a/test/payload.json.template
+++ b/test/payload.json.template
@@ -1,0 +1,10 @@
+{
+  "source": {
+    "server": "...",
+    "token": "...",
+    "insecure_skip_tls_verify": true
+  },
+  "params": {
+    "kubectl": "run nginx --image=nginx"
+  }
+}


### PR DESCRIPTION
This PR makes a small improvement that defaults `params` using jq's alternative operator (`//`).

```
$ echo '{}' | jq '.foo // 42'
42
```

- https://stedolan.github.io/jq/manual/#Alternativeoperator://