### PR TITLE
Add wait_until_ready_selector out parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Control the Kubernetes cluster like `kubectl apply`, `kubectl delete`, `kubectl 
 - `kubectl`: *Required.* Specify the operation that you want to perform on one or more resources, for example `apply`, `delete`, `label`.
 - `wait_until_ready`: *Optional.* The number of seconds that waits until all pods are ready. 0 means don't wait. Defaults to `30`.
 - `wait_until_ready_interval`: *Optional.* The interval (sec) on which to check whether all pods are ready. Defaults to `3`.
+- `wait_until_ready_selector`: *Optional.* [A label selector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) to identify a set of pods which to check whether those are ready. Defaults to every pods in the namespace.
 
 ## Example
 
@@ -84,6 +85,7 @@ jobs:
   - put: kubernetes-production
     params:
       kubectl: apply -f my-app/k8s -f my-app/k8s/production
+      wait_until_ready_selector: app=myapp
 ```
 
 ## License

--- a/assets/out
+++ b/assets/out
@@ -39,9 +39,11 @@ exe kubectl $kubectl_command
 wait_until_ready="$(jq -r '.params.wait_until_ready // 30' < $payload)"
 # Optional. The interval (sec) on which to check whether all pods are ready or not. Defaults to `3`.
 wait_until_ready_interval="$(jq -r '.params.wait_until_ready_interval // 3' < $payload)"
+# Optional. A label selector to identify a set of pods which to check whether those are ready. Defaults to every pods in the namespace.
+wait_until_ready_selector="$(jq -r '.params.wait_until_ready_selector // ""' < $payload)"
 
 if [[ "$wait_until_ready" -ne 0 ]]; then
-  wait_until_pods_ready $wait_until_ready $wait_until_ready_interval
+  wait_until_pods_ready "$wait_until_ready" "$wait_until_ready_interval" "$wait_until_ready_selector"
 fi
 
 jq --arg kubectl "$kubectl_command" \

--- a/test/payload.json.template
+++ b/test/payload.json.template
@@ -5,6 +5,7 @@
     "insecure_skip_tls_verify": true
   },
   "params": {
-    "kubectl": "run nginx --image=nginx"
+    "kubectl": "run nginx --image=nginx",
+    "wait_until_ready_selector": "run=nginx"
   }
 }


### PR DESCRIPTION
This PR adds a new out parameter `wait_until_ready_selector`. This out parameter is a label selector that allows you to identify a set of pods which to check whether those are ready. Defaults to every pods in the namespace.

```yaml
jobs:
- name: kubernetes-deploy-production
  plan:
  - get: my-app
    trigger: true
  - put: kubernetes-production
    params:
      kubectl: apply -f my-app/k8s -f my-app/k8s/production
      wait_until_ready_selector: app=myapp
```