### PR TITLE
List a set of pods caused the failure in wait_until_ready

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -106,7 +106,7 @@ wait_until_pods_ready() {
   for ((i=0; i<$period; i+=$interval)); do
     sleep "$interval"
 
-    statuses="$(kubectl get po --selector=$selector -o 'jsonpath={range .items[*]}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}')"
+    statuses="$(kubectl get po --selector=$selector -o 'jsonpath={range .items[*]}{.metadata.name} {.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}')"
     not_ready="$(echo "$statuses" | grep -c "False" ||:)"
     ready="$(echo "$statuses" | grep -c "True" ||:)"
 
@@ -117,7 +117,8 @@ wait_until_pods_ready() {
     fi
   done
 
-  echo "Waited for ${period}s, but all pods are not ready yet."
+  echo "Waited for ${period}s, but the following pods are not ready yet."
+  echo "$statuses" | awk '{print "- " $1}'
   return 1
 }
 


### PR DESCRIPTION
Previously, we could not know which pods caused the failure in `wait_until_ready`. With this PR it is improved to list a set of pods caused the failure as follows:

```
...
+ kubectl get po -l run=nginx
NAME                     READY     STATUS             RESTARTS   AGE
nginx-1280782513-1j3dx   0/1       ImagePullBackOff   0          13m
Waiting for pods to be ready for 1s (interval: 3s, selector: run=nginx)
Waiting for pods to be ready... (0/1)
Waited for 1s, but the following pods are not ready yet.
- nginx-1280782513-1j3dx

ERROR: Failed with error code 1
```