### PR TITLE
Fix to display only failure pods on wait_until_ready

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -118,7 +118,7 @@ wait_until_pods_ready() {
   done
 
   echo "Waited for ${period}s, but the following pods are not ready yet."
-  echo "$statuses" | awk '{print "- " $1}'
+  echo "$statuses" | awk '{if ($2 == "False") print "- " $1}'
   return 1
 }
 


### PR DESCRIPTION
This PR fixes to display only failure pods on wait_until_ready. Previously successful pods were also displayed.
```
...
+ kubectl cluster-info
Kubernetes master is running at https://192.168.99.102:8443

To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
+ kubectl get po -l run=nginx
NAME                     READY     STATUS             RESTARTS   AGE
nginx                    0/1       ImagePullBackOff   0          1h
nginx-4217019353-ws0qt   1/1       Running            0          1h
Waiting for pods to be ready for 30s (interval: 3s, selector: run=nginx)
Waiting for pods to be ready... (1/2)
Waiting for pods to be ready... (1/2)
Waiting for pods to be ready... (1/2)
Waiting for pods to be ready... (1/2)
Waiting for pods to be ready... (1/2)
Waiting for pods to be ready... (1/2)
Waiting for pods to be ready... (1/2)
Waiting for pods to be ready... (1/2)
Waiting for pods to be ready... (1/2)
Waiting for pods to be ready... (1/2)
Waited for 30s, but the following pods are not ready yet.
- nginx

ERROR: Failed with error code 1
```