### PR TITLE
Per Documentation check should return passed version

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@ List of contributors
 ====================
 
 Kazuki Suda
+Etourneau Gwenn

--- a/assets/check
+++ b/assets/check
@@ -12,5 +12,16 @@ set -o pipefail
 exec 3>&1 # make stdout available as fd 3 for the result
 exec 1>&2 # redirect all output to stderr for logging
 
-echo "$0 is not implemented."
-# vim: ai ts=2 sw=2 et sts=2 ft=sh
+PAYLOAD=$(mktemp /tmp/resource-check.XXXXXX)
+
+cat > "$PAYLOAD" <&0
+
+TS=$(jq '.version.timestamp // empty' < "$PAYLOAD")
+
+if [ -z "$TS" ]; then
+  echo '[]' >&3
+else
+  jq -n "[
+    { timestamp: $TS }
+  ]" >&3
+fi


### PR DESCRIPTION
According to the documentation

> If your resource is unable to determine which versions are newer then the given version (e.g. if it's a git commit that was push -fed over), then the current version of your resource should be returned (i.e. the new HEAD).

This PR just return the passed. 

http://concourse.ci/implementing-resources.html

(btw I don't have k8s setup so could not really tested)