### PR TITLE
Fix to be able to use command substitution in the kubectl param

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,20 @@ jobs:
       wait_until_ready_selector: app=myapp
 ```
 
+### Force update deployment
+
+```yaml
+jobs:
+- name: force-update-deployment
+  serial: true
+  plan:
+  - put: mycluster
+    params:
+      kubectl: |
+        patch deploy nginx -p '{"spec":{"template":{"metadata":{"labels":{"updated_at":"'$(date +%s)'"}}}}}'
+      wait_until_ready_selector: run=nginx
+```
+
 ## License
 
 This software is released under the MIT License.

--- a/assets/out
+++ b/assets/out
@@ -33,7 +33,7 @@ fi
 
 cd $source_dir
 
-exe kubectl $kubectl_command
+exe kubectl $(eval "echo $kubectl_command")
 
 # Optional. The number of seconds that waits until all pods are ready. Defaults to `30`.
 wait_until_ready="$(jq -r '.params.wait_until_ready // 30' < $payload)"


### PR DESCRIPTION
This commit fixes to be able to use command substitution in the
`kubectl` param. For example, command substitution is useful for
`kubectl patch` and so on, as below:

```yaml
jobs:
- name: force-update-deployment
  serial: true
  plan:
  - put: mycluster
    params:
      kubectl: |
        patch deploy nginx -p '{"spec":{"template":{"metadata":{"labels":{"updated_at":"'$(date +%s)'"}}}}}'
      wait_until_ready_selector: run=nginx
```

/fix #13