### PR TITLE
Adds namespace override

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ List of contributors
 
 Kazuki Suda
 Etourneau Gwenn
+Tanner Bruce

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The version of this resource corresponds to the version of kubectl. We recommend
       - cluster:
         ...
     ```
+- `context`: *Optional.* The context to use when specifying a `kubeconfig` or `kubeconfig_file`
 
 ### cluster configs
 
@@ -52,14 +53,13 @@ Control the Kubernetes cluster like `kubectl apply`, `kubectl delete`, `kubectl 
 
 #### Parameters
 
-- `context`: *Optional.* The context to use when specifying a `kubeconfig` or `kubeconfig_file`
-- `namespace`: *Optional.* The namespace to default to. Defaults to `default`.
 - `kubectl`: *Required.* Specify the operation that you want to perform on one or more resources, for example `apply`, `delete`, `label`.
-- `wait_until_ready`: *Optional.* Set to `true` if you want to wait until all pods are ready. Defaults to *all* pods in the namespace. 
-- `wait_until_ready_timeout`: *Optional.* The number of seconds that waits until all pods are ready. 0 means don't wait. Defaults to `30`.
+- `context`: *Optional.* The context to use when specifying a `kubeconfig` or `kubeconfig_file`
+- `wait_until_ready`: *Optional.* The number of seconds that waits until all pods are ready. 0 means don't wait. Defaults to `30`.
 - `wait_until_ready_interval`: *Optional.* The interval (sec) on which to check whether all pods are ready. Defaults to `3`.
 - `wait_until_ready_selector`: *Optional.* [A label selector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) to identify a set of pods which to check whether those are ready. Defaults to every pods in the namespace.
 - `kubeconfig_file`: *Optional.* The path of kubeconfig file. This param has priority over the `kubeconfig` of source configuration.
+- `namespace`: *Optional.* The namespace scope. It will override the namespace in other params and source configuration.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The version of this resource corresponds to the version of kubectl. We recommend
 
 - `server`: *Optional.* The address and port of the API server. Requires `token`.
 - `token`: *Optional.* Bearer token for authentication to the API server. Requires `server`.
-- `namespace`: *Optional.* The namespace scope. Defaults to `default`.
+- `namespace`: *Optional.* The namespace scope. Defaults to `default`. If set along with `kubeconfig`, `namespace` will override the namespace in the current-context
 - `certificate_authority`: *Optional.* A certificate file for the certificate authority.
     ```yaml
     certificate_authority: |
@@ -52,8 +52,11 @@ Control the Kubernetes cluster like `kubectl apply`, `kubectl delete`, `kubectl 
 
 #### Parameters
 
+- `context`: *Optional.* The context to use when specifying a `kubeconfig` or `kubeconfig_file`
+- `namespace`: *Optional.* The namespace to default to. Defaults to `default`.
 - `kubectl`: *Required.* Specify the operation that you want to perform on one or more resources, for example `apply`, `delete`, `label`.
-- `wait_until_ready`: *Optional.* The number of seconds that waits until all pods are ready. 0 means don't wait. Defaults to `30`.
+- `wait_until_ready`: *Optional.* Set to `true` if you want to wait until all pods are ready. Defaults to *all* pods in the namespace. 
+- `wait_until_ready_timeout`: *Optional.* The number of seconds that waits until all pods are ready. 0 means don't wait. Defaults to `30`.
 - `wait_until_ready_interval`: *Optional.* The interval (sec) on which to check whether all pods are ready. Defaults to `3`.
 - `wait_until_ready_selector`: *Optional.* [A label selector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) to identify a set of pods which to check whether those are ready. Defaults to every pods in the namespace.
 - `kubeconfig_file`: *Optional.* The path of kubeconfig file. This param has priority over the `kubeconfig` of source configuration.

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -31,8 +31,6 @@ setup_kubectl() {
     local server="$(jq -r '.source.server // ""' < $payload)"
     # Optional. Bearer token for authentication to the API server. Requires server.
     local token="$(jq -r '.source.token // ""' < $payload)"
-    # Optional. The namespace scope. Defaults to default if doesn't specify in kubeconfig.
-    local namespace="$(jq -r '.source.namespace // ""' < $payload)"
     # Optional. A certificate file for the certificate authority.
     local certificate_authority="$(jq -r '.source.certificate_authority // ""' < $payload)"
     # Optional. If true, the API server's certificate will not be checked for
@@ -67,17 +65,17 @@ setup_kubectl() {
     fi
     exe kubectl config set-cluster $CLUSTER_NAME $set_cluster_opts
 
-    # Build options for kubectl config set-context
-    local set_context_opts="--user=$AUTH_NAME --cluster=$CLUSTER_NAME"
-    if [[ -n "$namespace" ]]; then
-      set_context_opts="$set_context_opts --namespace=$namespace"
-    fi
-    exe kubectl config set-context $CONTEXT_NAME $set_context_opts
+    exe kubectl config set-context $CONTEXT_NAME --user=$AUTH_NAME --cluster=$CLUSTER_NAME
 
     exe kubectl config use-context $CONTEXT_NAME
   fi
 
-  local namespace="$(jq -r '.source.namespace // ""' < $payload)"
+  # Optional. The namespace scope. Defaults to default if doesn't specify in kubeconfig.
+  local namespace="$(jq -r '.params.namespace // ""' < $payload)"
+  if [[ -z "$namespace" ]]; then
+    # Optional. The namespace scope. Defaults to `default`. If set along with `kubeconfig`, `namespace` will override the namespace in the current-context
+    namespace="$(jq -r '.source.namespace // ""' < $payload)"
+  fi
   if [[ -n "$namespace" ]]; then
     exe kubectl config set-context $(kubectl config current-context) --namespace="$namespace"
   fi

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -77,6 +77,11 @@ setup_kubectl() {
     exe kubectl config use-context $CONTEXT_NAME
   fi
 
+  local namespace="$(jq -r '.source.namespace // ""' < $payload)"
+  if [[ -n "$namespace" ]]; then
+    exe kubectl config set-context $(kubectl config current-context) --namespace="$namespace"
+  fi
+
   # Optional. The name of the kubeconfig context to use.
   local context="$(jq -r '.source.context // ""' < $payload)"
   if [[ -n "$context" ]]; then

--- a/assets/out
+++ b/assets/out
@@ -34,18 +34,28 @@ if [[ -z "$kubectl_command" ]]; then
   exit 1
 fi
 
+namespace="$(jq -r '.params.namespace // ""' < $payload)"
+if [[ -n "$namespace" ]]; then
+  exe kubectl config set-context $(kubectl config current-context) --namespace="$namespace"
+fi
+
 exe kubectl $(eval "echo $kubectl_command")
 
-# Optional. The number of seconds that waits until all pods are ready. Defaults to `30`.
-wait_until_ready="$(jq -r '.params.wait_until_ready // 30' < $payload)"
-# Optional. The interval (sec) on which to check whether all pods are ready or not. Defaults to `3`.
-wait_until_ready_interval="$(jq -r '.params.wait_until_ready_interval // 3' < $payload)"
-# Optional. A label selector to identify a set of pods which to check whether those are ready. Defaults to every pods in the namespace.
-wait_until_ready_selector="$(jq -r '.params.wait_until_ready_selector // ""' < $payload)"
+# Optional. Specify if we should wait until pods are ready.
+wait_until_ready_enabled="$(jq -r '.params.wait_until_ready_enabled' < $payload)"
 
-if [[ "$wait_until_ready" -ne 0 ]]; then
+# wait if wait_until_ready_enabled is unset, or if it is true (wait by default)
+if [[ -z $wait_until_ready_enabled || $wait_until_ready_enabled == "true" ]] ; then
+  # Optional. The number of seconds that waits until all pods are ready. Defaults to `30`.
+  wait_until_ready="$(jq -r '.params.wait_until_ready // 30' < $payload)"
+  # Optional. The interval (sec) on which to check whether all pods are ready or not. Defaults to `3`.
+  wait_until_ready_interval="$(jq -r '.params.wait_until_ready_interval // 3' < $payload)"
+  # Optional. A label selector to identify a set of pods which to check whether those are ready. Defaults to every pods in the namespace.
+  wait_until_ready_selector="$(jq -r '.params.wait_until_ready_selector // ""' < $payload)"
+
   wait_until_pods_ready "$wait_until_ready" "$wait_until_ready_interval" "$wait_until_ready_selector"
 fi
+
 
 jq --arg kubectl "$kubectl_command" \
    --arg namespace "$(current_namespace)" \

--- a/assets/out
+++ b/assets/out
@@ -34,28 +34,18 @@ if [[ -z "$kubectl_command" ]]; then
   exit 1
 fi
 
-namespace="$(jq -r '.params.namespace // ""' < $payload)"
-if [[ -n "$namespace" ]]; then
-  exe kubectl config set-context $(kubectl config current-context) --namespace="$namespace"
-fi
-
 exe kubectl $(eval "echo $kubectl_command")
 
-# Optional. Specify if we should wait until pods are ready.
-wait_until_ready_enabled="$(jq -r '.params.wait_until_ready_enabled' < $payload)"
+# Optional. The number of seconds that waits until all pods are ready. Defaults to `30`.
+wait_until_ready="$(jq -r '.params.wait_until_ready // 30' < $payload)"
+# Optional. The interval (sec) on which to check whether all pods are ready or not. Defaults to `3`.
+wait_until_ready_interval="$(jq -r '.params.wait_until_ready_interval // 3' < $payload)"
+# Optional. A label selector to identify a set of pods which to check whether those are ready. Defaults to every pods in the namespace.
+wait_until_ready_selector="$(jq -r '.params.wait_until_ready_selector // ""' < $payload)"
 
-# wait if wait_until_ready_enabled is unset, or if it is true (wait by default)
-if [[ -z $wait_until_ready_enabled || $wait_until_ready_enabled == "true" ]] ; then
-  # Optional. The number of seconds that waits until all pods are ready. Defaults to `30`.
-  wait_until_ready="$(jq -r '.params.wait_until_ready // 30' < $payload)"
-  # Optional. The interval (sec) on which to check whether all pods are ready or not. Defaults to `3`.
-  wait_until_ready_interval="$(jq -r '.params.wait_until_ready_interval // 3' < $payload)"
-  # Optional. A label selector to identify a set of pods which to check whether those are ready. Defaults to every pods in the namespace.
-  wait_until_ready_selector="$(jq -r '.params.wait_until_ready_selector // ""' < $payload)"
-
+if [[ "$wait_until_ready" -ne 0 ]]; then
   wait_until_pods_ready "$wait_until_ready" "$wait_until_ready_interval" "$wait_until_ready_selector"
 fi
-
 
 jq --arg kubectl "$kubectl_command" \
    --arg namespace "$(current_namespace)" \


### PR DESCRIPTION
This PR allows us to override the namespace via `source` or `params` of output, and also documents the `namespace` flag, and has added docs for the `context` flag.

This PR is based on #21, but it removes the changes for `wait_until_ready` because it is breaking changes.