### PR TITLE
Count "not ready" pods correctly

### DIFF
--- a/test/suite.bats
+++ b/test/suite.bats
@@ -70,3 +70,12 @@ teardown() {
   assert_not_equal "<no value>" "${lines[0]}"
   assert_success
 }
+
+@test "pending pod" {
+  # Request large resources, so that pod will fall into Pending state
+  run assets/out <<< "$(jq -n '{"source": {"kubeconfig": $kubeconfig}, "params": {"kubectl": $kubectl}}' \
+    --arg kubeconfig "$(cat "$kubeconfig_file")" \
+    --arg kubectl "run nginx --image nginx --requests='cpu=1000'")"
+  assert_match 'deployment.apps "nginx" created' "$output"
+  assert_failure
+}


### PR DESCRIPTION
Some pods (for example, Pending pods) don't have "Ready" condition.
So we can't decide which pods are "not ready" using it.
This patch fixes this issue.

Fixes #34