### PR TITLE
Add scripts/update-authors.sh that updates AUTHORS file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,5 +35,6 @@ before_script:
 - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
 
 script:
+- ./scripts/verify-authors.sh
 - make lint
 - make test

--- a/AUTHORS
+++ b/AUTHORS
@@ -5,4 +5,5 @@ Kazuki Suda
 Etourneau Gwenn
 Tanner Bruce
 Takuhiro Yoshida
+O. Yuanying
 Anne Schuth

--- a/scripts/update-authors.sh
+++ b/scripts/update-authors.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+SCRIPT_ROOT="$(dirname "${BASH_SOURCE}")/.."
+AUTHORS_FILE="${AUTHORS_FILE:-"${SCRIPT_ROOT}/AUTHORS"}"
+
+cat <<EOL > "$AUTHORS_FILE"
+List of contributors
+====================
+
+$(git log  --format='%at,%an' | sort -t, -n | awk -F, '{if (!a[$2]++) print $2;}')
+EOL

--- a/scripts/verify-authors.sh
+++ b/scripts/verify-authors.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+SCRIPT_ROOT="$(dirname "${BASH_SOURCE}")/.."
+TMP_ROOT="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap "cleanup" EXIT SIGINT
+
+export AUTHORS_FILE="${TMP_ROOT}/AUTHORS"
+"${SCRIPT_ROOT}/scripts/update-authors.sh"
+
+ret=0
+diff "${SCRIPT_ROOT}/AUTHORS" "$AUTHORS_FILE" || ret=$?
+
+if [[ $ret -eq 0 ]]; then
+  echo "AUTHORS is up to date."
+else
+  echo "AUTHORS is out of date. Please run scripts/update-authors.sh."
+fi


### PR DESCRIPTION
This PR adds `scripts/update-authors.sh` that updates AUTHORS file from git log.

In addition, `scripts/verify-authors.sh` that verify AUTHORS file is up to date is added. This verification script runs in CI.