### PR TITLE
Fix verify-authors.sh to fail if AUTHORS is out of date

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,5 @@ Tanner Bruce
 Takuhiro Yoshida
 O. Yuanying
 Anne Schuth
+Werner Buck
+Lucas de Haas

--- a/scripts/verify-authors.sh
+++ b/scripts/verify-authors.sh
@@ -20,4 +20,5 @@ if [[ $ret -eq 0 ]]; then
   echo "AUTHORS is up to date."
 else
   echo "AUTHORS is out of date. Please run scripts/update-authors.sh."
+  exit 1
 fi


### PR DESCRIPTION
This PR fixes `scripts/verify-authors.sh` to fail if AUTHORS file is out of date. In addition, AUTHORS file is updated.