### PR TITLE
Merge kubeconfig files using "kubectl config view" 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ The version of this resource corresponds to the version of kubectl. We recommend
 
 ### cluster configs
 
-- `server`: *Optional.* The address and port of the API server. Requires `token`.
-- `token`: *Optional.* Bearer token for authentication to the API server. Requires `server`.
+- `server`: *Optional.* The address and port of the API server.
+- `token`: *Optional.* Bearer token for authentication to the API server.
 - `namespace`: *Optional.* The namespace scope. Defaults to `default`. If set along with `kubeconfig`, `namespace` will override the namespace in the current-context
 - `certificate_authority`: *Optional.* A certificate file for the certificate authority.
     ```yaml

--- a/test/helper.bash
+++ b/test/helper.bash
@@ -39,3 +39,11 @@ assert_match() {
     return 1
   fi
 }
+
+assert_not_match() {
+  if [[ "$2" =~ $1 ]]; then
+    echo "expected: $1"
+    echo "actual: $2"
+    return 1
+  fi
+}

--- a/test/suite.bats
+++ b/test/suite.bats
@@ -12,6 +12,15 @@ setup() {
   kubectl config view --flatten --minify > "$kubeconfig_file"
   # Change the current-context to $namespace
   kubectl --kubeconfig "$kubeconfig_file" config set-context ${current_context} --namespace "$namespace"
+  # Create a kubeconfig json without users (no token)
+  kubeconfig_file_no_token="$(mktemp)"
+  kubectl config view --flatten --minify -o json | jq -r 'del(.contexts[0].context.user,.users)' > "$kubeconfig_file_no_token"
+  # create rolebinding for full namespace access to default service account in namespace to avoid forbidden errors with token
+  kubectl create -n $namespace rolebinding --clusterrole=cluster-admin --serviceaccount=$namespace:default testaccount
+  # get default service account
+  serviceaccount=$(kubectl get -n $namespace serviceaccount default -o json | jq -r '.secrets[0].name')
+  # Extract token from service account for testing
+  token="$(kubectl get -n $namespace secret "$serviceaccount" -o json | jq -r '.data["token"]' | base64 -d)"
 }
 
 teardown() {
@@ -55,6 +64,16 @@ teardown() {
     --arg kubectl "get po nginx" \
     --arg namespace "kube-system")"
   assert_failure
+}
+
+@test "with no credentials in outputs.kubeconfig_file and source.token" {
+  run assets/out <<< "$(jq -n '{"source": {"token": $token}, "params": {"kubectl": $kubectl, "kubeconfig_file": $kubeconfig_file, "namespace": $namespace}}' \
+    --arg token "$token" \
+    --arg kubeconfig_file "$kubeconfig_file_no_token" \
+    --arg kubectl "get ns $namespace -o name" \
+    --arg namespace "$namespace")"
+  assert_match "namespace/$namespace" "$output"
+  assert_success
 }
 
 @test "command substitution in outputs.kubectl" {


### PR DESCRIPTION
When using `use_aws_iam_authenticator`, the kubeconfig file is broken
due to merging by shell redirection. With this commit, the kubeconfig
file is merged by `kubectl config view` command instead of shell
redirection.

/fix #45 