### PR TITLE
Add ability to use env variables for aws-iam-authenticator

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@ O. Yuanying
 Anne Schuth
 Werner Buck
 Lucas de Haas
+Daniel Jensen

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ The version of this resource corresponds to the version of kubectl. We recommend
 - `insecure_skip_tls_verify`: *Optional.* If true, the API server's certificate will not be checked for validity. This will make your HTTPS connections insecure. Defaults to `false`.
 - `use_aws_iam_authenticator`: *Optional.* If true, the aws_iam_authenticator, required for connecting with EKS, is used. Requires `aws_eks_cluster_name`. Defaults to `false`.
 - `aws_eks_cluster_name`: *Optional.* the AWS EKS cluster name, required when `use_aws_iam_authenticator` is true.
+- `aws_access_key_id`: *Optional.* Sets environment variable AWS_ACCESS_KEY_ID
+- `aws_secret_access_key`: *Optional.* Sets environment variable AWS_SECRET_ACCESS_KEY
 
 ## Behavior
 

--- a/assets/out
+++ b/assets/out
@@ -38,12 +38,13 @@ fi
 IFS=" " read -r -a kubectl_arguments <<< "$(eval "echo $kubectl_command")"
 exe kubectl "${kubectl_arguments[@]}"
 
+
 # Optional. The number of seconds that waits until all pods are ready. Defaults to `30`.
 wait_until_ready="$(jq -r '.params.wait_until_ready // 30' < "$payload")"
 # Optional. The interval (sec) on which to check whether all pods are ready or not. Defaults to `3`.
 wait_until_ready_interval="$(jq -r '.params.wait_until_ready_interval // 3' < "$payload")"
 # Optional. A label selector to identify a set of pods which to check whether those are ready. Defaults to every pods in the namespace.
-wait_until_ready_selector="$(jq -r '.params.wait_until_ready_selector // ""' < "$payload")"
+wait_until_ready_selector="$(jq -r '.params.wait_until_ready // 30' < "$payload")"
 
 if [[ "$wait_until_ready" -ne 0 ]]; then
   wait_until_pods_ready "$wait_until_ready" "$wait_until_ready_interval" "$wait_until_ready_selector"

--- a/assets/out
+++ b/assets/out
@@ -44,7 +44,7 @@ wait_until_ready="$(jq -r '.params.wait_until_ready // 30' < "$payload")"
 # Optional. The interval (sec) on which to check whether all pods are ready or not. Defaults to `3`.
 wait_until_ready_interval="$(jq -r '.params.wait_until_ready_interval // 3' < "$payload")"
 # Optional. A label selector to identify a set of pods which to check whether those are ready. Defaults to every pods in the namespace.
-wait_until_ready_selector="$(jq -r '.params.wait_until_ready // 30' < "$payload")"
+wait_until_ready_selector="$(jq -r '.params.wait_until_ready_selector // ""' < "$payload")"
 
 if [[ "$wait_until_ready" -ne 0 ]]; then
   wait_until_pods_ready "$wait_until_ready" "$wait_until_ready_interval" "$wait_until_ready_selector"


### PR DESCRIPTION
This allows a user to specify AWS access keys to authenticate with aws-iam-authenticator