### PR TITLE
Use kind for integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ go:
 
 env:
   matrix:
-  - KUBECTL_VERSION=v1.13.0
-  - KUBECTL_VERSION=v1.12.0
-  - KUBECTL_VERSION=v1.11.0
+  - KUBECTL_VERSION=v1.13.0 NODE_VERSION=v1.12.3 # v1.13.x hasn't been released yet
+  - KUBECTL_VERSION=v1.12.0 NODE_VERSION=v1.12.3
+  - KUBECTL_VERSION=v1.11.0 NODE_VERSION=v1.11.3
 
 services:
 - docker
@@ -18,7 +18,7 @@ before_script:
 # Build and install kind
 - go get sigs.k8s.io/kind
 # Create a new kubernetes cluster
-- kind create cluster
+- kind create cluster --image="kindest/node:${NODE_VERSION}"
 # Set KUBECONFIG environment variable
 - export KUBECONFIG="$(kind get kubeconfig-path)"
 # Show version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,41 +1,44 @@
-sudo: required
+language: go
 
-language: bash
+go:
+- "1.11.x"
+
+env:
+  matrix:
+  - KUBECTL_VERSION=v1.13.0
+  - KUBECTL_VERSION=v1.12.0
+  - KUBECTL_VERSION=v1.11.0
 
 services:
 - docker
 
-sudo: required
-
-env:
-  global:
-  - TMPDIR=/tmp
-  - CHANGE_MINIKUBE_NONE_USER=true
-  - MINIKUBE_VERSION=v0.28.0
-  - MINIKUBE_ARGS="--vm-driver=none --bootstrapper=localkube --extra-config=apiserver.Authorization.Mode=RBAC"
-  matrix:
-  - KUBE_VERSION=v1.10.0
-  - KUBE_VERSION=v1.11.0
-
-matrix:
-  allow_failures:
-    - env: KUBE_VERSION=v1.11.0
-
 before_script:
-# Download kubectl, which is a requirement for using minikube.
-- curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-# Download minikube.
-- curl -Lo minikube https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
-- sudo minikube start --kubernetes-version=${KUBE_VERSION} ${MINIKUBE_ARGS}
-# Fix the kubectl context, as it's often stale.
-- sudo minikube update-context
-# Prevent Permission denied
-- sudo chown -R ${USER} ${HOME}/.kube ${HOME}/.minikube
-# Wait for Kubernetes to be up and ready.
-- JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
+# Download and install kubectl
+- curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+# Build and install kind
+- go get sigs.k8s.io/kind
+# Create a new kubernetes cluster
+- kind create cluster
+# Set KUBECONFIG environment variable
+- export KUBECONFIG="$(kind get kubeconfig-path)"
+# Show version
+- kubectl version
 
 script:
-- ./scripts/verify-authors.sh
-- make lint
 - make test
-- make image
+
+matrix:
+  include:
+  - &bash
+    language: bash
+    go: null
+    env: null
+    before_script: null
+    script:
+    - ./scripts/verify-authors.sh
+  - <<: *bash
+    script:
+    - make lint
+  - <<: *bash
+    script:
+    - make image

--- a/assets/out
+++ b/assets/out
@@ -12,6 +12,9 @@ set -o pipefail
 exec 3>&1 # make stdout available as fd 3 for the result
 exec 1>&2 # redirect all output to stderr for logging
 
+# Set TMPDIR environment variable to /tmp if it does not defined
+export TMPDIR="${TMPDIR:-/tmp}"
+
 # shellcheck source=assets/common.sh
 source "$(dirname "$0")/common.sh"
 

--- a/scripts/run-bats.sh
+++ b/scripts/run-bats.sh
@@ -2,17 +2,7 @@
 
 set -e
 
-context="$(kubectl config current-context)"
-
-# Change the current-context to minikube
-kubectl config use-context minikube
-
 for bats_file in $(find test -name "*.bats"); do
   echo "=> $bats_file"
   bats "$bats_file"
 done
-
-if [[ "$context" != "minikube" ]]; then
-  echo "Restore the current-context to $context"
-  kubectl config use-context "$context"
-fi

--- a/test/suite.bats
+++ b/test/suite.bats
@@ -44,7 +44,7 @@ teardown() {
   run assets/out <<< "$(jq -n '{"source": {"kubeconfig": $kubeconfig}, "params": {"kubectl": $kubectl}}' \
     --arg kubeconfig "$(cat "$kubeconfig_file")" \
     --arg kubectl "run nginx --image nginx")"
-  assert_match 'deployment.apps "nginx" created' "$output"
+  assert_match 'deployment.apps/nginx created' "$output"
   assert_success
 }
 
@@ -93,7 +93,7 @@ teardown() {
   run assets/out <<< "$(jq -n '{"source": {"kubeconfig": $kubeconfig}, "params": {"kubectl": $kubectl}}' \
     --arg kubeconfig "$(cat "$kubeconfig_file")" \
     --arg kubectl "patch deploy nginx -p '{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"updated_at\":\"'\$(date +%s)'\"}}}}}'")"
-  assert_match 'deployment.extensions "nginx" patched' "$output"
+  assert_match 'deployment.extensions/nginx patched' "$output"
   assert_success
 
   run kubectl --kubeconfig "$kubeconfig_file" get deploy nginx -o go-template --template "{{.spec.template.metadata.labels.updated_at}}"
@@ -106,6 +106,6 @@ teardown() {
   run assets/out <<< "$(jq -n '{"source": {"kubeconfig": $kubeconfig}, "params": {"kubectl": $kubectl}}' \
     --arg kubeconfig "$(cat "$kubeconfig_file")" \
     --arg kubectl "run nginx --image nginx --requests='cpu=1000'")"
-  assert_match 'deployment.apps "nginx" created' "$output"
+  assert_match 'deployment.apps/nginx created' "$output"
   assert_failure
 }


### PR DESCRIPTION
This PR changes to use kind for integration test instead of minikube. localkube is already deprecated and no longer released new version. kind is new tool that can setup local clusters for testing.

- https://github.com/kubernetes-sigs/kind