### PR TITLE
Use aws-iam-authenticator which is specified the version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,26 @@
-FROM golang:1.12
-
-RUN set -x && \
-    GO111MODULE=on go get -u -v github.com/kubernetes-sigs/aws-iam-authenticator/cmd/aws-iam-authenticator
-
 FROM ubuntu:18.04
 
 MAINTAINER Kazuki Suda <ksuda@zlab.co.jp>
 
 ARG KUBERNETES_VERSION=
 
+# Do NOT update the next line manually, please use ./scripts/update-aws-iam-authenticator.sh instead
+ARG AWS_IAM_AUTHENTICATOR_VERSION=v0.4.0
+
 RUN set -x && \
     apt-get update && \
     apt-get install -y jq curl && \
+    # Download and install kubectl
     [ -z "$KUBERNETES_VERSION" ] && KUBERNETES_VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt) ||: && \
     curl -s -LO https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin/kubectl && \
     kubectl version --client && \
+    # Download and install aws-iam-authenticator
+    curl -s -L -o /usr/local/bin/aws-iam-authenticator "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/${AWS_IAM_AUTHENTICATOR_VERSION}/aws-iam-authenticator_$(echo "$AWS_IAM_AUTHENTICATOR_VERSION" | tr -d v)_linux_amd64" && \
+    chmod +x /usr/local/bin/aws-iam-authenticator && \
+    aws-iam-authenticator version && \
     rm -rf /var/lib/apt/lists/*
-
-COPY --from=0 /go/bin/aws-iam-authenticator /usr/local/bin/
 
 RUN mkdir -p /opt/resource
 COPY assets/* /opt/resource/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A Concourse resource for controlling the Kubernetes cluster.
 
-*This resource supports AWS EKS.*
+*This resource supports AWS EKS. (kubernetes-sigs/aws-iam-authenticator@v0.4.0)*
 
 ## Versions
 

--- a/scripts/update-aws-iam-authenticator.sh
+++ b/scripts/update-aws-iam-authenticator.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail; [[ -n "$DEBUG" ]] && set -x
+
+AWS_IAM_AUTHENTICATOR_VERSION="$1"
+if [[ -z "$AWS_IAM_AUTHENTICATOR_VERSION" ]]; then
+    echo "Usage: $0 <version>" >&2
+    exit 1
+fi
+
+sed -i -e "s/^ARG AWS_IAM_AUTHENTICATOR_VERSION=v[0-9\.]*$/ARG AWS_IAM_AUTHENTICATOR_VERSION=$AWS_IAM_AUTHENTICATOR_VERSION/" Dockerfile
+sed -i -e "s/aws-iam-authenticator@v[0-9\.]*/aws-iam-authenticator@${AWS_IAM_AUTHENTICATOR_VERSION}/" README.md


### PR DESCRIPTION
aws-iam-authenticator is now failed to build (https://github.com/kubernetes-sigs/aws-iam-authenticator/issues/240). Due to this, we now cannot build kubernetes-resource container image successfully. 

For avoiding this situation, this PR changes to download and install aws-iam-authenticator's binary instead building it from source code.