### PR TITLE
Upgrade kind to v0.4.0 and use kindest/node v1.15.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: bash
 
 env:
   matrix:
-  - KUBECTL_VERSION=v1.15.0 NODE_VERSION=v1.14.2@sha256:33539d830a6cf20e3e0a75d0c46a4e94730d78c7375435e6b49833d81448c319
-  - KUBECTL_VERSION=v1.14.0 NODE_VERSION=v1.14.2@sha256:33539d830a6cf20e3e0a75d0c46a4e94730d78c7375435e6b49833d81448c319
-  - KUBECTL_VERSION=v1.13.0 NODE_VERSION=v1.13.6@sha256:9e07014fb48c746deb98ec8aafd58c3918622eca6063e643c6e6d86c86e170b4
+  - KUBECTL_VERSION=v1.15.0 NODE_VERSION=v1.15.0@sha256:b4d092fd2b507843dd096fe6c85d06a27a0cbd740a0b32a880fe61aba24bb478
+  - KUBECTL_VERSION=v1.14.0 NODE_VERSION=v1.14.3@sha256:583166c121482848cd6509fbac525dd62d503c52a84ff45c338ee7e8b5cfe114
+  - KUBECTL_VERSION=v1.13.0 NODE_VERSION=v1.13.7@sha256:f3f1cfc2318d1eb88d91253a9c5fa45f6e9121b6b1e65aea6c7ef59f1549aaaf
 
 services:
 - docker
@@ -13,7 +13,7 @@ before_script:
 # Download and install kubectl
 - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 # Download and install kind
-- curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-linux-amd64 && chmod +x kind && sudo mv kind /usr/local/bin/
+- curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/v0.4.0/kind-linux-amd64 && chmod +x kind && sudo mv kind /usr/local/bin/
 # Create a new kubernetes cluster
 - kind create cluster --image="kindest/node:${NODE_VERSION}"
 # Set KUBECONFIG environment variable


### PR DESCRIPTION
This PR upgrades `kind` to v0.4.0 and changes to use kindest/node:v1.15.0.