### PR TITLE
Add support for Kubernetes 1.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: bash
 
 env:
   matrix:
+  - KUBECTL_VERSION=v1.16.0 NODE_VERSION=v1.15.3
   - KUBECTL_VERSION=v1.15.0 NODE_VERSION=v1.15.3
   - KUBECTL_VERSION=v1.14.0 NODE_VERSION=v1.14.2
-  - KUBECTL_VERSION=v1.13.0 NODE_VERSION=v1.13.6
 
 services:
 - docker

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ A Concourse resource for controlling the Kubernetes cluster.
 
 The version of this resource corresponds to the version of kubectl. We recommend using different version depending on the kubernetes version of the cluster.
 
+ - `zlabjp/kubernetes-resource:1.16` ([stable-1.16](https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt))
  - `zlabjp/kubernetes-resource:1.15` ([stable-1.15](https://storage.googleapis.com/kubernetes-release/release/stable-1.15.txt))
  - `zlabjp/kubernetes-resource:1.14` ([stable-1.14](https://storage.googleapis.com/kubernetes-release/release/stable-1.14.txt))
- - `zlabjp/kubernetes-resource:1.13` ([stable-1.13](https://storage.googleapis.com/kubernetes-release/release/stable-1.13.txt))
  - `zlabjp/kubernetes-resource:latest` ([latest](https://storage.googleapis.com/kubernetes-release/release/latest.txt))
 
 ## Source Configuration
@@ -81,7 +81,7 @@ resource_types:
   type: docker-image
   source:
     repository: zlabjp/kubernetes-resource
-    tag: "1.14"
+    tag: "1.16"
 
 resources:
 - name: kubernetes-production

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -4,7 +4,7 @@
 # DO NOT MAKE CHANGES TO THIS FILE. Instead, modify ci/pipeline.yml.erb and
 # execute build-pipeline-yml.
 #
-# created: 2019-06-21T05:05:12+00:00
+# created: 2019-09-26T17:16:56+09:00
 #
 resource_types:
 - name: slack-notification
@@ -44,14 +44,6 @@ resources:
     url: ((slack-url))
 
 
-- name: kubernetes-resource-image-1.13
-  type: docker-image
-  source:
-    repository: zlabjp/kubernetes-resource
-    tag: "1.13"
-    username: ((docker-username))
-    password: ((docker-password))
-
 - name: kubernetes-resource-image-1.14
   type: docker-image
   source:
@@ -65,6 +57,14 @@ resources:
   source:
     repository: zlabjp/kubernetes-resource
     tag: "1.15"
+    username: ((docker-username))
+    password: ((docker-password))
+
+- name: kubernetes-resource-image-1.16
+  type: docker-image
+  source:
+    repository: zlabjp/kubernetes-resource
+    tag: "1.16"
     username: ((docker-username))
     password: ((docker-password))
 
@@ -86,12 +86,6 @@ resources:
     password: ((docker-password))
 
 
-- name: stable-1.13
-  type: file-url
-  source:
-    url: https://storage.googleapis.com/kubernetes-release/release/stable-1.13.txt
-    filename: version
-
 - name: stable-1.14
   type: file-url
   source:
@@ -102,6 +96,12 @@ resources:
   type: file-url
   source:
     url: https://storage.googleapis.com/kubernetes-release/release/stable-1.15.txt
+    filename: version
+
+- name: stable-1.16
+  type: file-url
+  source:
+    url: https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
     filename: version
 
 - name: latest
@@ -150,44 +150,6 @@ jobs:
         text: |
           Failure! $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
 
-
-- name: build-kubernetes-resource-image-1.13
-  public: true
-  serial: true
-  plan:
-  - do:
-    - aggregate:
-      - get: kubernetes-resource-release
-        trigger: true
-      - get: ubuntu-18.04
-        params: {save: true}
-        trigger: true
-      - get: stable-1.13
-        trigger: true
-    - task: build-build-args-file
-      file: kubernetes-resource-release/ci/tasks/build-build-args-file.yml
-      input_mapping: {version: stable-1.13}
-    - put: kubernetes-resource-image-1.13
-      params:
-        build: kubernetes-resource-release
-        load_base: ubuntu-18.04
-        build_args_file: output/build-args-file
-    on_success:
-      put: notify
-      params:
-        channel: ((slack-success-channel))
-        username: concourse / kubernetes-resource-image-1.13
-        icon_emoji: ":dancing-penguin:"
-        text: |
-          Success! $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
-    on_failure:
-      put: notify
-      params:
-        channel: ((slack-failure-channel))
-        username: concourse / kubernetes-resource-image-1.13
-        icon_emoji: ":rage:"
-        text: |
-          Failure! $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
 
 - name: build-kubernetes-resource-image-1.14
   public: true
@@ -261,6 +223,44 @@ jobs:
       params:
         channel: ((slack-failure-channel))
         username: concourse / kubernetes-resource-image-1.15
+        icon_emoji: ":rage:"
+        text: |
+          Failure! $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
+
+- name: build-kubernetes-resource-image-1.16
+  public: true
+  serial: true
+  plan:
+  - do:
+    - aggregate:
+      - get: kubernetes-resource-release
+        trigger: true
+      - get: ubuntu-18.04
+        params: {save: true}
+        trigger: true
+      - get: stable-1.16
+        trigger: true
+    - task: build-build-args-file
+      file: kubernetes-resource-release/ci/tasks/build-build-args-file.yml
+      input_mapping: {version: stable-1.16}
+    - put: kubernetes-resource-image-1.16
+      params:
+        build: kubernetes-resource-release
+        load_base: ubuntu-18.04
+        build_args_file: output/build-args-file
+    on_success:
+      put: notify
+      params:
+        channel: ((slack-success-channel))
+        username: concourse / kubernetes-resource-image-1.16
+        icon_emoji: ":dancing-penguin:"
+        text: |
+          Success! $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
+    on_failure:
+      put: notify
+      params:
+        channel: ((slack-failure-channel))
+        username: concourse / kubernetes-resource-image-1.16
         icon_emoji: ":rage:"
         text: |
           Failure! $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME

--- a/ci/pipeline.yml.erb
+++ b/ci/pipeline.yml.erb
@@ -1,5 +1,5 @@
 <%
-  kubernetes_versions = %w(stable-1.13 stable-1.14 stable-1.15 latest)
+  kubernetes_versions = %w(stable-1.14 stable-1.15 stable-1.16 latest)
   def tag(version); version.sub(/^stable-/, ''); end
   def image_resource_name(version); "kubernetes-resource-image-" + tag(version); end
 


### PR DESCRIPTION
This PR adds support for Kubernetes 1.16. `docker.io/zlabjp/kubernetes-resource:1.16` has already published.